### PR TITLE
Correct example docs for Anima#add and #remove

### DIFF
--- a/lib/anima.rb
+++ b/lib/anima.rb
@@ -31,8 +31,8 @@ class Anima < Module
   # @return [Anima]
   #
   # @example
-  #   anima = Anima.new(:foo, :bar)
-  #   anima.add(:foo) # equals Anima.new(:foo, :bar)
+  #   anima = Anima.new(:foo)
+  #   anima.add(:bar) # equals Anima.new(:foo, :bar)
   #
   # @api private
   #
@@ -45,7 +45,7 @@ class Anima < Module
   # @return [Anima]
   #
   # @example
-  #   anima = Anima.new(:foo)
+  #   anima = Anima.new(:foo, :bar)
   #   anima.remove(:bar) # equals Anima.new(:foo)
   #
   # @api public


### PR DESCRIPTION
Looks like these commits first moved methods around, then got the doc-example comments a little out of whack.

https://github.com/mbj/anima/commit/d73dba18b51742be0c07046dd6370b37c47538e7
https://github.com/mbj/anima/commit/2bb9776ccec77f823be592ac98b31a8d4ad576b0
