### PR TITLE
Change Anima::InstanceMethods#to_h to accept a block

### DIFF
--- a/lib/anima.rb
+++ b/lib/anima.rb
@@ -91,14 +91,17 @@ class Anima < Module
 
     # Return a hash representation of an anima infected object
     #
-    # @example
+    # @example without block
     #   anima.to_h # => { :foo => : bar }
+    #
+    # @example with block
+    #   anima.to_h { |key, value| [key.to_s, value.to_s] }  # => { 'foo' => 'bar' }
     #
     # @return [Hash]
     #
     # @api public
-    def to_h
-      self.class.anima.attributes_hash(self)
+    def to_h(&block)
+      self.class.anima.attributes_hash(self).to_h(&block)
     end
 
     # Return updated instance

--- a/spec/unit/anima_spec.rb
+++ b/spec/unit/anima_spec.rb
@@ -168,8 +168,6 @@ describe Anima do
   end
 
   describe '#to_h on an anima infected instance' do
-    subject { instance.to_h }
-
     let(:instance) { klass.new(params) }
     let(:params)   { Hash[foo: :bar] }
     let(:klass) do
@@ -178,7 +176,17 @@ describe Anima do
       end
     end
 
-    it { should eql(params) }
+    context 'without a block' do
+      subject { instance.to_h }
+
+      it { should eql(params) }
+    end
+
+    context 'with a block' do
+      subject { instance.to_h { |key, value| [key.to_s, value.to_s] } }
+
+      it { should eql('foo' => 'bar') }
+    end
   end
 
   describe '#with' do


### PR DESCRIPTION
## Summary

This branch changes Anima::InstanceMethods#to_h to accept an optional block.

This behaviour is similar to Hash#to_h in Ruby 2.6+.

## Changes

- Change Anima::InstanceMethods#to_h to accept a block
